### PR TITLE
Export rules disabled by multiple users

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Usage of ./irae:
   -check-s3-connection
         check S3 connection and exit
   -disabled-by-more-users
-         export rules disabled by more users
+         export rules disabled by more than one user
   -metadata
         export metadata
   -output string

--- a/README.md
+++ b/README.md
@@ -64,17 +64,20 @@ contribute to this project.
 Usage of ./irae:
   -authors
         show authors
-  -output string
-        output to: CSV, S3
+  -check-s3-connection
+        check S3 connection and exit
+  -disabled-by-more-users
+         export rules disabled by more users
   -metadata
         export metadata
+  -output string
+        output to: CSV, S3
   -show-configuration
         show configuration
   -summary
         print summary table after export
   -version
         show version
-
 ```
 
 ### Building

--- a/csv.go
+++ b/csv.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 )
 
+// DisabledRulesToCSV function exports list of disabled rules + number of users
+// who disabled rules to CSV file.
 func DisabledRulesToCSV(buffer io.Writer, disabledRulesInfo []DisabledRuleInfo) error {
 	writer := csv.NewWriter(buffer)
 

--- a/csv.go
+++ b/csv.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2021, 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/csv"
+	"io"
+	"strconv"
+)
+
+func DisabledRulesToCSV(buffer io.Writer, disabledRulesInfo []DisabledRuleInfo) error {
+	writer := csv.NewWriter(buffer)
+
+	var data = [][]string{{"Rule", "Count"}}
+
+	err := writer.WriteAll(data)
+	if err != nil {
+		return err
+	}
+
+	for _, disabledRuleInfo := range disabledRulesInfo {
+		err := writer.Write([]string{
+			disabledRuleInfo.Rule,
+			strconv.Itoa(disabledRuleInfo.Count)})
+		if err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+
+	// check for any error during export to CSV
+	err = writer.Error()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/exporter.go
+++ b/exporter.go
@@ -68,6 +68,12 @@ const (
 	disabledRules = "_disabled_rules.csv"
 )
 
+// messages
+const (
+	readDisabledRulesInfoFailed      = "Read disabled rules info failed"
+	storeDisabledRulesIntoFileFailed = "Store disabled rules into file failed"
+)
+
 // showVersion function displays version information.
 func showVersion() {
 	fmt.Println(versionMessage)
@@ -172,7 +178,7 @@ func performDataExportToS3(configuration *ConfigStruct,
 		// export rules disabled by more users into CSV file
 		disabledRulesInfo, err := storage.ReadDisabledRules()
 		if err != nil {
-			log.Err(err).Msg("Read disabled rules info failed")
+			log.Err(err).Msg(readDisabledRulesInfoFailed)
 			return ExitStatusStorageError, err
 		}
 
@@ -180,7 +186,7 @@ func performDataExportToS3(configuration *ConfigStruct,
 		err = storeDisabledRulesIntoS3(context, minioClient, bucket,
 			disabledRules, disabledRulesInfo)
 		if err != nil {
-			log.Err(err).Msg("Store disabled rules into file failed")
+			log.Err(err).Msg(storeDisabledRulesIntoFileFailed)
 			return ExitStatusIOError, err
 		}
 	}
@@ -240,14 +246,14 @@ func performDataExportToFiles(configuration *ConfigStruct,
 		// export rules disabled by more users into CSV file
 		disabledRulesInfo, err := storage.ReadDisabledRules()
 		if err != nil {
-			log.Err(err).Msg("Read disabled rules info failed")
+			log.Err(err).Msg(readDisabledRulesInfoFailed)
 			return ExitStatusStorageError, err
 		}
 
 		// export list of disabled rules
 		err = storeDisabledRulesIntoFile(disabledRules, disabledRulesInfo)
 		if err != nil {
-			log.Err(err).Msg("Store disabled rules into file failed")
+			log.Err(err).Msg(storeDisabledRulesIntoFileFailed)
 			return ExitStatusIOError, err
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -23,6 +23,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Messages
+const (
+	writeTableNameToCSV        = "Write table name to CSV"
+	writeDisabledRuleInfoToCSV = "Write disabled rule info to CSV"
+)
+
 // storeTableNamesIntoFile function stores names of all tables into the
 // specified file
 func storeTableNamesIntoFile(fileName string, tableNames []TableName) error {
@@ -48,7 +54,7 @@ func storeTableNamesIntoFile(fileName string, tableNames []TableName) error {
 	for _, tableName := range tableNames {
 		err := writer.Write([]string{string(tableName)})
 		if err != nil {
-			log.Error().Err(err).Msg("Write table name to CSV")
+			log.Error().Err(err).Msg(writeTableNameToCSV)
 		}
 	}
 
@@ -83,7 +89,7 @@ func storeDisabledRulesIntoFile(fileName string, disabledRulesInfo []DisabledRul
 	// conversion to CSV
 	err = DisabledRulesToCSV(fout, disabledRulesInfo)
 	if err != nil {
-		log.Error().Err(err).Msg("Write table name to CSV")
+		log.Error().Err(err).Msg(writeDisabledRuleInfoToCSV)
 		return err
 	}
 

--- a/file.go
+++ b/file.go
@@ -68,3 +68,30 @@ func storeTableNamesIntoFile(fileName string, tableNames []TableName) error {
 
 	return nil
 }
+
+// storeDisabledRulesIntoFile function stores info about disabled rules into
+// specified file
+func storeDisabledRulesIntoFile(fileName string, disabledRulesInfo []DisabledRuleInfo) error {
+	// open new CSV file to be filled in
+
+	// disable "G304 (CWE-22): Potential file inclusion via variable"
+	fout, err := os.Create(fileName) // #nosec G304
+	if err != nil {
+		return err
+	}
+
+	// conversion to CSV
+	err = DisabledRulesToCSV(fout, disabledRulesInfo)
+	if err != nil {
+		log.Error().Err(err).Msg("Write table name to CSV")
+		return err
+	}
+
+	// close the file and check if close operation was ok
+	err = fout.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/storage.go
+++ b/storage.go
@@ -654,7 +654,7 @@ func writeColumnNames(writer *csv.Writer, colNames []string) error {
 	return nil
 }
 
-// ReadDisabledRules method reads rules disabled by more that one user
+// ReadDisabledRules method reads rules disabled by more than one user
 func (storage DBStorage) ReadDisabledRules() ([]DisabledRuleInfo, error) {
 	// slice to make list of disabled rule
 	var disabledRulesInfo = make([]DisabledRuleInfo, 0)

--- a/storage_test.go
+++ b/storage_test.go
@@ -121,7 +121,8 @@ func checkAllExpectations(t *testing.T, mock sqlmock.Sqlmock) {
 
 // Expected queries
 const (
-	readRecordCountQuery = "SELECT count\\(\\*\\) FROM TESTED_TABLE"
+	readRecordCountQuery   = "SELECT count\\(\\*\\) FROM TESTED_TABLE"
+	readDisabledRulesQuery = "SELECT rule_id, count\\(rule_id\\) AS rule_count FROM rule_disable GROUP BY rule_id HAVING count\\(rule_id\\)\\>1 ORDER BY rule_count DESC;"
 )
 
 // check the function ReadRecordCount
@@ -208,6 +209,67 @@ func TestReadRecordCountOnError(t *testing.T) {
 
 	if count != -1 {
 		t.Errorf("wrong number records returned: %d", count)
+	}
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// check the function ReadDisabledRules
+func TestReadDisabledRulesOnError(t *testing.T) {
+	// error to be thrown
+	mockedError := errors.New("mocked error")
+
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// expected query performed by tested function
+	mock.ExpectQuery(readDisabledRulesQuery).WillReturnError(mockedError)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := main.NewFromConnection(connection, 1)
+
+	// call the tested method
+	_, err := storage.ReadDisabledRules()
+
+	if err != mockedError {
+		t.Errorf("different error was returned: %v", err)
+	}
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// check the function ReadDisabledRules
+func TestReadDisabledRulesScanError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"rule", "count"})
+	rows.AddRow("rule1", "not count")
+	rows.AddRow("rule2", "not count")
+	rows.AddRow("rule3", "not count")
+
+	// expected query performed by tested function
+	expectedQuery := "SELECT rule_id, count\\(rule_id\\) AS rule_count FROM rule_disable GROUP BY rule_id HAVING count\\(rule_id\\)\\>1 ORDER BY rule_count DESC;"
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := main.NewFromConnection(connection, 1)
+
+	// call the tested method
+	_, err := storage.ReadDisabledRules()
+	if err == nil {
+		t.Errorf("error was expected")
 	}
 
 	// connection to mocked DB needs to be closed properly

--- a/types.go
+++ b/types.go
@@ -22,15 +22,22 @@ type DBDriver int
 // TableName type represents table name
 type TableName string
 
+// DisabledRuleInfo contains information about rules disabled by user
+type DisabledRuleInfo struct {
+	Rule  string
+	Count int
+}
+
 // CliFlags represents structure holding all command line arguments and flags.
 type CliFlags struct {
-	ShowVersion       bool
-	ShowAuthors       bool
-	ShowConfiguration bool
-	PrintSummaryTable bool
-	Output            string
-	CheckS3Connection bool
-	ExportMetadata    bool
+	ShowVersion         bool
+	ShowAuthors         bool
+	ShowConfiguration   bool
+	PrintSummaryTable   bool
+	Output              string
+	CheckS3Connection   bool
+	ExportMetadata      bool
+	ExportDisabledRules bool
 }
 
 // M represents a map with string keys and any value


### PR DESCRIPTION
# Description

Ability to export rules disabled by multiple users

Fixes #68

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
