### PR TITLE
Fixed: ioutil.ReadFile is deprecated

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -46,7 +46,7 @@ func mustCreateTemporaryDirectory(t *testing.T) string {
 // mustReadFile helper function tries to read specified file and return its
 // content as a string
 func mustReadFile(t *testing.T, filename string) string {
-	fileContent, err := ioutil.ReadFile(filename)
+	fileContent, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

Fixed: ioutil.ReadFile is deprecated

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
