### PR TITLE
Fixed: ioutil.ReadFile is deprecated

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -25,6 +25,7 @@ package main_test
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"database/sql"

--- a/storage_test.go
+++ b/storage_test.go
@@ -568,7 +568,7 @@ func TestStoreTableIntoFile(t *testing.T) {
 	checkAllExpectations(t, mock)
 
 	// check generated file
-	content, err := ioutil.ReadFile("table_name.csv")
+	content, err := os.ReadFile("table_name.csv")
 	if err != nil {
 		t.Errorf("error during reading file %s", err)
 	}


### PR DESCRIPTION
# Description

Fixed: ioutil.ReadFile is deprecated

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
