### PR TITLE
Add configurable prefix for S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,26 @@ Exporter for Insights Results data stored by Insights Results Aggregator
 * [Documentation](#documentation)
 * [Contribution](#contribution)
 * [Usage](#usage)
-    * [Building](#building)
+	* [Building](#building)
 * [CI/CD](#cicd)
 * [Makefile targets](#makefile-targets)
-    * [Configuration](#configuration)
+	* [Configuration](#configuration)
 * [BDD tests](#bdd-tests)
 * [Example output](#example-output)
-    * [List of files/objects](#list-of-filesobjects)
-    * [Content of `_tables.csv`](#content-of-_tablescsv)
-    * [Content of `_metadata.csv`](#content-of-_metadatacsv)
-    * [Content of `advisor_ratings.csv`](#content-of-advisor_ratingscsv)
-    * [Content of `cluster_rule_toggle.csv`](#content-of-cluster_rule_togglecsv)
-    * [Content of `cluster_rule_user_feedback.csv`](#content-of-cluster_rule_user_feedbackcsv)
-    * [Content of `cluster_user_rule_disable_feedback.csv`](#content-of-cluster_user_rule_disable_feedbackcsv)
-    * [Content of `migration_info.csv`](#content-of-migration_infocsv)
-    * [Content of `consumer_error.csv`](#content-of-consumer_errorcsv)
-    * [Content of `recommendation.csv`](#content-of-recommendationcsv)
-    * [Content of `report.csv`](#content-of-reportcsv)
-    * [Content of `report_info.csv`](#content-of-report_infocsv)
-    * [Content of `rule_disable.csv`](#content-of-rule_disablecsv)
-    * [Content of `rule_hit.csv`](#content-of-rule_hitcsv)
+	* [List of files/objects](#list-of-filesobjects)
+	* [Content of `_tables.csv`](#content-of-_tablescsv)
+	* [Content of `_metadata.csv`](#content-of-_metadatacsv)
+	* [Content of `advisor_ratings.csv`](#content-of-advisor_ratingscsv)
+	* [Content of `cluster_rule_toggle.csv`](#content-of-cluster_rule_togglecsv)
+	* [Content of `cluster_rule_user_feedback.csv`](#content-of-cluster_rule_user_feedbackcsv)
+	* [Content of `cluster_user_rule_disable_feedback.csv`](#content-of-cluster_user_rule_disable_feedbackcsv)
+	* [Content of `migration_info.csv`](#content-of-migration_infocsv)
+	* [Content of `consumer_error.csv`](#content-of-consumer_errorcsv)
+	* [Content of `recommendation.csv`](#content-of-recommendationcsv)
+	* [Content of `report.csv`](#content-of-reportcsv)
+	* [Content of `report_info.csv`](#content-of-report_infocsv)
+	* [Content of `rule_disable.csv`](#content-of-rule_disablecsv)
+	* [Content of `rule_hit.csv`](#content-of-rule_hitcsv)
 * [Package manifest](#package-manifest)
 
 <!-- vim-markdown-toc -->
@@ -168,6 +168,7 @@ access_key_id = "foobar"
 secret_access_key = "foobar"
 use_ssl = false
 bucket = "test"
+prefix = "prefix"
 
 [logging]
 debug = true
@@ -195,6 +196,7 @@ INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__ACCESS_KEY_ID
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__SECRET_ACCESS_KEY
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__USE_SSL
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__BUCKET
+INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__DEBUG
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__LOG_DEVEL
 INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__SENTRY__DSN

--- a/config.go
+++ b/config.go
@@ -73,6 +73,7 @@ package main
 // INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__SECRET_ACCESS_KEY
 // INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__USE_SSL
 // INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__BUCKET
+// INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX
 // INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__DEBUG
 // INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__LOG_DEVEL
 
@@ -100,9 +101,9 @@ const (
 // ConfigStruct is a structure holding the whole service configuration
 type ConfigStruct struct {
 	Storage StorageConfiguration `mapstructure:"storage" toml:"storage"`
-	S3      S3Configuration      `mapstructure:"s3" tomp:"s3"`
+	S3      S3Configuration      `mapstructure:"s3"      toml:"s3"`
 	Logging LoggingConfiguration `mapstructure:"logging" toml:"logging"`
-	Sentry  SentryConfiguration  `mapstructure:"sentry" toml:"sentry"`
+	Sentry  SentryConfiguration  `mapstructure:"sentry"  toml:"sentry"`
 }
 
 // LoggingConfiguration represents configuration for logging in general
@@ -148,6 +149,7 @@ type S3Configuration struct {
 	SecretAccessKey string `mapstructure:"secret_access_key" toml:"secret_access_key"`
 	UseSSL          bool   `mapstructure:"use_ssl"           toml:"use_ssl"`
 	Bucket          string `mapstructure:"bucket"            toml:"bucket"`
+	Prefix          string `mapstructure:"prefix"            toml:"prefix"`
 }
 
 // SentryConfiguration represents the configuration of Sentry logger

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ access_key_id = "foobar"
 secret_access_key = "foobar"
 use_ssl = false
 bucket = "test"
+prefix = "test_path"
 
 [logging]
 debug = true

--- a/config_test.go
+++ b/config_test.go
@@ -162,6 +162,7 @@ func TestLoadS3Configuration(t *testing.T) {
 
 	assert.Equal(t, "minio", S3Cfg.Type)
 	assert.Equal(t, false, S3Cfg.UseSSL)
+	assert.Equal(t, "test_path", S3Cfg.Prefix)
 }
 
 // TestLoadConfigurationFromEnvVariableClowderEnabled tests loading the config.

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -85,6 +85,8 @@ objects:
               name: ccx-results-exporter-s3
               key: bucket
               optional: true
+        - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX
+          value: ${DB_NAME}
         - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__DEBUG
           value: "${DEBUG}"
         - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__LOG_DEVEL

--- a/export_test.go
+++ b/export_test.go
@@ -41,6 +41,7 @@ var (
 	CheckS3Connection         = checkS3Connection
 	PerformDataExport         = performDataExport
 	ConstructIgnoredTablesMap = constructIgnoredTablesMap
+	GetS3Bucket               = getS3Bucket
 
 	// exported functions from the s3.go source file
 	S3BucketExists  = s3BucketExists

--- a/exporter.go
+++ b/exporter.go
@@ -138,6 +138,7 @@ func showConfiguration(config *ConfigStruct) {
 		Str("SecretAccessKey", s3Configuration.SecretAccessKey).
 		Bool("Use SSL", s3Configuration.UseSSL).
 		Str("Bucket name", s3Configuration.Bucket).
+		Str("Bucket prefix", s3Configuration.Prefix).
 		Msg("S3 configuration")
 }
 
@@ -222,7 +223,8 @@ func performDataExportToS3(configuration *ConfigStruct,
 	// log into terminal
 	printTables(tableNames)
 
-	bucket := GetS3Configuration(configuration).Bucket
+	bucket := GetS3Configuration(configuration).Prefix + "/" + GetS3Configuration(configuration).Bucket
+
 	log.Info().Str("bucket name", bucket).Msg("S3 bucket to write to")
 
 	if exportMetadata {

--- a/exporter.go
+++ b/exporter.go
@@ -194,6 +194,14 @@ func performDataExport(configuration *ConfigStruct, cliFlags CliFlags, operation
 	}
 }
 
+func getS3Bucket(configuration *ConfigStruct) string {
+	bucket, bucketPrefix := GetS3Configuration(configuration).Bucket, GetS3Configuration(configuration).Prefix
+	if bucketPrefix != "" {
+		bucket = bucketPrefix + "/" + bucket
+	}
+	return bucket
+}
+
 // performDataExportToS3 exports all tables and metadata info configured S3
 // bucket
 func performDataExportToS3(configuration *ConfigStruct,
@@ -223,8 +231,7 @@ func performDataExportToS3(configuration *ConfigStruct,
 	// log into terminal
 	printTables(tableNames)
 
-	bucket := GetS3Configuration(configuration).Prefix + "/" + GetS3Configuration(configuration).Bucket
-
+	bucket := getS3Bucket(configuration)
 	log.Info().Str("bucket name", bucket).Msg("S3 bucket to write to")
 
 	if exportMetadata {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -401,3 +401,16 @@ func TestConstructIgnoreTableMapTwoTables(t *testing.T) {
 	assert.Contains(t, m, "table1")
 	assert.Contains(t, m, "table2")
 }
+
+func TestGetS3Bucket(t *testing.T) {
+	config := main.ConfigStruct{}
+	assert.Equal(t, "", main.GetS3Bucket(&config))
+
+	testBucketString := "test_bucket"
+	config.S3.Bucket = testBucketString
+	assert.Equal(t, testBucketString, main.GetS3Bucket(&config))
+
+	testBucketPrefixString := "test_prefix"
+	config.S3.Prefix = testBucketPrefixString
+	assert.Equal(t, testBucketPrefixString+"/"+testBucketString, main.GetS3Bucket(&config))
+}

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -17,6 +17,7 @@ access_key_id = "foobar"
 secret_access_key = "foobar"
 use_ssl = false
 bucket = "test"
+prefix = "test_path"
 
 [logging]
 debug = true


### PR DESCRIPTION
# Description

Configurable prefix for S3 destination bucket.
Using the INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX environment variable, we can define an output path with the {PREFIX}/_metadata.csv format

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- Updated UTs

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
