### PR TITLE
Temporal fix for wrong bucket name

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -86,7 +86,7 @@ objects:
               key: bucket
               optional: true
         - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__S3__PREFIX
-          value: ${DB_NAME}
+          value: ""
         - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__DEBUG
           value: "${DEBUG}"
         - name: INSIGHTS_RESULTS_AGGREGATOR_EXPORTER__LOGGING__LOG_DEVEL


### PR DESCRIPTION
# Description

Bucket name can only contain characters 0-9a-Z

## Type of change

- Bug fix (non-breaking change which fixes an issue)