### PR TITLE
Fix S3 destination paths depending on the target database

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@ access_key_id = "foobar"
 secret_access_key = "foobar"
 use_ssl = false
 bucket = "test"
-prefix = "test_path"
+prefix = ""
 
 [logging]
 debug = true

--- a/export_test.go
+++ b/export_test.go
@@ -41,7 +41,7 @@ var (
 	CheckS3Connection         = checkS3Connection
 	PerformDataExport         = performDataExport
 	ConstructIgnoredTablesMap = constructIgnoredTablesMap
-	GetS3Bucket               = getS3Bucket
+	SetObjectPrefix           = setObjectPrefix
 
 	// exported functions from the s3.go source file
 	S3BucketExists  = s3BucketExists

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -402,15 +402,7 @@ func TestConstructIgnoreTableMapTwoTables(t *testing.T) {
 	assert.Contains(t, m, "table2")
 }
 
-func TestGetS3Bucket(t *testing.T) {
-	config := main.ConfigStruct{}
-	assert.Equal(t, "", main.GetS3Bucket(&config))
-
-	testBucketString := "test_bucket"
-	config.S3.Bucket = testBucketString
-	assert.Equal(t, testBucketString, main.GetS3Bucket(&config))
-
-	testBucketPrefixString := "test_prefix"
-	config.S3.Prefix = testBucketPrefixString
-	assert.Equal(t, testBucketPrefixString+"/"+testBucketString, main.GetS3Bucket(&config))
+func TestSetObjectPrefix(t *testing.T) {
+	assert.Equal(t, "test/bucket", main.SetObjectPrefix("test", "bucket"))
+	assert.Equal(t, "bucket", main.SetObjectPrefix("", "bucket"))
 }

--- a/storage.go
+++ b/storage.go
@@ -391,7 +391,7 @@ func (storage DBStorage) ReadTable(tableName TableName, limit int) ([]M, error) 
 
 // StoreTable function stores specified table into S3/Minio
 func (storage DBStorage) StoreTable(ctx context.Context,
-	minioClient *minio.Client, bucketName string, tableName TableName,
+	minioClient *minio.Client, bucketName, prefix string, tableName TableName,
 	limit int) error {
 	columnTypes, err := storage.RetrieveColumnTypes(tableName)
 	if err != nil {
@@ -429,7 +429,7 @@ func (storage DBStorage) StoreTable(ctx context.Context,
 	size := buffer.Len()
 
 	options := minio.PutObjectOptions{ContentType: "text/csv"}
-	objectName := string(tableName) + ".csv"
+	objectName := setObjectPrefix(prefix, string(tableName)) + ".csv"
 	_, err = minioClient.PutObject(ctx, bucketName, objectName, reader, int64(size), options)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

The previous commit was using the prefix in the bucket name, which is not allowed. With this change, the objects created within the bucket are appended with the correct prefix

Fixes #149 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps

Change has been tested using [awslocal](https://github.com/localstack/awscli-local), creating buckets with and without prefixes to ensure it works as expected.
BDD tests. under development.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
