### PR TITLE
[CCXDEV-8886] Use a random CJI suffix

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -31,7 +31,7 @@ objects:
   metadata:
     labels:
       app: ccx-results-exporter
-    name: ${DB_NAME}-job-launcher
+    name: ${DB_NAME}-job-launcher-${CJI_RANDOM_SUFFIX}
   spec:
     appName: ccx-results-exporter-${DB_NAME}
     jobs:
@@ -44,3 +44,7 @@ parameters:
 - name: DB_NAME
   required: true
   value: ccx-data-pipeline
+- name: CJI_RANDOM_SUFFIX
+  description: A suffix for generating random CJI
+  from: '[a-z]{8}'
+  generate: expression


### PR DESCRIPTION
# Description

We are seeing an error in the [app-interface CI](https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/153693/console):

```
10:48:05 [2022-08-09 08:48:05] [ERROR] [saasherder.py:populate_desired_state_saas_file:1153] - [crcs02ue1/ccx-data-pipeline-stage] desired item already exists: ClowdJobInvocation/ccx-data-pipeline-job-launcher. saas file name: ccx-data-pipeline-post-deploy-jobs, resource template name: insights-notification-exporter-cji.
```

I can see 2 reasons why it's failing (at least):
1. we have 2 CJI with the same name: one from stage and other for prod
2. the old CJIs are not deleted so each time we deploy a new version, the CJI has the same name as a previous one, so it cannot be deployed

Adding a random suffix will make the name unique.

Trying to fix #CCXDEV-8886

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

None yet.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
