### PR TITLE
Dont use io.TempDir

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,8 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-
+          args: --timeout=3m
+          
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/file_test.go
+++ b/file_test.go
@@ -23,7 +23,6 @@ package main_test
 // https://redhatinsights.github.io/insights-results-aggregator-exporter/packages/file_test.html
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -35,7 +34,7 @@ import (
 // mustCreateTemporaryDirectory helper function creates temporary directory
 // that will be cleaned up after tests
 func mustCreateTemporaryDirectory(t *testing.T) string {
-	directory, err := ioutil.TempDir(os.TempDir(), "exporter")
+	directory, err := os.MkdirTemp(os.TempDir(), "exporter")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

`io.TempDir` is depreacted: [see](https://cs.opensource.google/go/go/+/go1.19:src/io/ioutil/tempfile.go;l=39).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Unit tests.

## Checklist
* [ ] `make before_commit` passes (it doesn't because the code coverage being too low)
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
