### PR TITLE
name too long fix

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -24,7 +24,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ccx-results-exporter-${DB_NAME}-cji
+  name: exporter-${DB_NAME}-cji
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
@@ -33,7 +33,7 @@ objects:
       app: ccx-results-exporter
     name: ${DB_NAME}-job-launcher-${CJI_RANDOM_SUFFIX}
   spec:
-    appName: ccx-results-exporter-${DB_NAME}
+    appName: exporter-${DB_NAME}
     jobs:
       - instance
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,12 +16,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ccx-results-exporter-${DB_NAME}
+  name: exporter-${DB_NAME}
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: ccx-results-exporter-${DB_NAME}
+    name: exporter-${DB_NAME}
   spec:
     envName: ${ENV_NAME}
     testing:


### PR DESCRIPTION
# Description

kubernetes support only 63 characters for resource names. Some autogenerated names exceed that limit

Fixes ...

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
## Testing steps
n/a

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
