### PR TITLE
[CCXDEV-9132] clowdapp - set proper dependencies

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -24,6 +24,9 @@ objects:
     name: exporter-${DB_NAME}
   spec:
     envName: ${ENV_NAME}
+    dependencies:
+      - ccx-notification-writer
+      - ccx-insights-results-aggregator
     testing:
       iqePlugin: ccx
     jobs:


### PR DESCRIPTION
# Description

To be able use clowder's  'sharedDbAppName' the clowder dependencies should be properly set.

## Type of change

- Bug fix (non-breaking change which fixes an issue)