### PR TITLE
Update builder image to Go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.16 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.17 AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

Update Go Toolset base image to 1.17. Fixing some CVEs problem

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Bump-up dependent library (no changes in the code)

## Testing steps

Nop, relying on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
