### PR TITLE
Using latest tagged go-toolset:1.17 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.17 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.17.12-11 AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

In order to fix some CVE the team decided to point to specific base images, so we can unsure that we use an specific version (and force the rebuild of the image) that already fix the CVE problem

## Type of change

- Security fix in dependent library (no changes in the code)

## Testing steps

Built image locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
