### PR TITLE
[CCXDEV-10346] Revert "log a test error so that we can check glitchtip works (#197)"

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -24,7 +24,6 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -562,8 +561,6 @@ func mainWithStatusCode() int {
 	}
 
 	defer loggingCloser()
-
-	log.Error().Err(errors.New("test error")).Msg("this is a test error")
 
 	var buffer bytes.Buffer
 	operationLogger, err := createOperationLog(cliFlags, &buffer)


### PR DESCRIPTION
# Description

This reverts commit 3e56e574de80f3bf50a19809f30ce009fb43035a.

I already checked in stage and prod so this is not needed anymore.

## Type of change

Logging.

## Testing steps

Stage and prod.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
