### PR TITLE
fix selective export query, org_id is STRING not INT

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -90,7 +90,7 @@ var (
 		"advisor_ratings",
 	}
 
-	whereOrgIDFilter = " WHERE org_id IN (%v)"
+	whereOrgIDFilter = " WHERE org_id IN ('%v')"
 )
 
 // Storage represents an interface to almost any database or storage system
@@ -713,6 +713,6 @@ func selectiveExportAllowed(tablename TableName) bool {
 
 func (storage DBStorage) applySelectiveExport(sqlStatement *string, tablename TableName) {
 	if storage.config.EnableOrgIDFiltering && selectiveExportAllowed(tablename) {
-		*sqlStatement += fmt.Sprintf(whereOrgIDFilter, strings.Join(storage.config.OrganizationsToExport, ","))
+		*sqlStatement += fmt.Sprintf(whereOrgIDFilter, strings.Join(storage.config.OrganizationsToExport, "','"))
 	}
 }


### PR DESCRIPTION
# Description
`org_id` is string, not int... adding quotation marks to the `WHERE org_id IN (%v)` query append

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make test`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
