### PR TITLE
improve ephemeral_import.sh script

### DIFF
--- a/ephemeral_import.sh
+++ b/ephemeral_import.sh
@@ -18,6 +18,7 @@
 # see the docs on how to login to the eph. cluster https://ccx.pages.redhat.com/ccx-docs/docs/processing/howto/ephemeral_env/
 
 GREEN_BG=$(tput setab 2)
+RED_BG=$(tput setab 1)
 NC=$(tput sgr0) # No Color
 
 APP_NAME="ccx-data-pipeline" 
@@ -36,7 +37,7 @@ TABLES=(
 )
 
 # define reserved namespace if you want to use a special one
-EPH_NAMESPACE=""
+EPH_NAMESPACE=${EPH_NAMESPACE:=""}
 DB_POD=""
 
 export IQE_ENV="ephemeral"
@@ -89,7 +90,7 @@ function wait_for_db_pod() {
    DB_POD=""
    while [[ ${DB_POD} == "" ]]
    do
-      sleep 3
+      sleep 5
       DB_POD=$(oc get pods --selector='app=ccx-insights-results, service=db' | grep "ccx-insights-results-db-*" | awk '{print $1}')
    done
 
@@ -99,21 +100,41 @@ function wait_for_db_pod() {
       echo "waiting for DB pod timed out, exiting"
       exit 1
    fi
-   echo "${GREEN_BG}DB pod ready${NC}"
+   echo "${GREEN_BG}DB pod ${DB_POD} ready${NC}"
+}
+
+function wait_for_db_writer_pod() {
+   # wait for DB writer pod to be Ready, it will not be in a Ready state until all init containers finish,
+   # ensuring the DB migrations will be finished before we proceed
+   DB_WRITER_POD=""
+   while [[ ${DB_WRITER_POD} == "" ]]
+   do
+      sleep 3
+      DB_WRITER_POD=$(oc get pods --selector='app=ccx-insights-results, pod=ccx-insights-results-db-writer' | grep "ccx-insights-results-db-writer-*" | awk '{print $1}')
+   done
+
+   # we have the pod name, we can use oc wait command to wait for Ready state, ensuring init contianers finish
+   echo "${GREEN_BG}DB writer pod ${DB_WRITER_POD} found, waiting for database migrations to finish${NC}"
+   if ! oc wait --for=condition=Ready pod/${DB_WRITER_POD} --timeout=2m; then
+      echo "waiting for DB migrations to finish timed out, exiting"
+      exit 1
+   fi
+   echo "${GREEN_BG}DB pod ${DB_WRITER_POD} ready${NC}"
 }
 
 function check_login() {
    if ! oc whoami;
    then
-      echo "please login to the ephemeral cluster via 'oc login'"
-      echo "https://ccx.pages.redhat.com/ccx-docs/docs/processing/howto/ephemeral_env/"
+      echo "${RED_BG}please login to the ephemeral cluster via 'oc login'${NC}"
+      echo "${RED_BG}https://ccx.pages.redhat.com/ccx-docs/docs/processing/howto/ephemeral_env/${NC}"
       exit 1
    fi
 }
 
-function reserve_ephemeral_namespace() {
-   echo "reserving new ephemeral namespace"
+function reserve_new_ephemeral_namespace() {
+   echo "${GREEN_BG}reserving new ephemeral namespace${NC}"
    EPH_NAMESPACE=$(bonfire namespace reserve)
+   echo "${GREEN_BG}extending namespace reservation by 2 hours${NC}"
    bonfire namespace extend ${EPH_NAMESPACE} -d '2h0m'
 }
 
@@ -121,24 +142,26 @@ function get_ephemeral_namespace() {
    if [[ $EPH_NAMESPACE == "" ]];
    then
       # try to find an already existing namespace
-      FIRST_AVAILABLE=$(bonfire namespace list --mine | grep 'ephemeral-*' | awk '{print $1}')
+      FIRST_AVAILABLE=$(bonfire namespace list --mine | grep 'ephemeral-*' | awk '{print $1}' | head -1)
       if [[ $FIRST_AVAILABLE != "" ]];
       then 
          echo "${GREEN_BG}Existing ephemeral namespace found, do you want to use ${FIRST_AVAILABLE}?${NC}"
          select yn in "Yes" "No"; do
             case $yn in
                Yes ) EPH_NAMESPACE=${FIRST_AVAILABLE}; break;;
-               No ) reserve_ephemeral_namespace; break;;
+               No ) echo "${RED_BG}please pick a namespace and export the EPH_NAMESPACE env var${NC}"; break;;
             esac
          done
       else
-         reserve_ephemeral_namespace
+         echo "${GREEN_BG}no existing namespace found${NC}"
+         reserve_new_ephemeral_namespace
       fi
    fi
 }
 
-echo "${GREEN_BG}checking login${NC}"
+echo "checking login"
 check_login
+echo "${GREEN_BG}user logged in to the ephemeral cluster${NC}"
 
 echo "${GREEN_BG}getting ephemeral namespace${NC}"
 get_ephemeral_namespace
@@ -159,9 +182,13 @@ generate_import_script
 
 echo "${GREEN_BG}copying exported data to DB pod${NC}"
 copy_testdata
+echo "${GREEN_BG}data copied succesfully to DB pod${NC}"
+
+echo "${GREEN_BG}waiting for database migrations to finish${NC}"
+wait_for_db_writer_pod
 
 echo "${GREEN_BG}executing import script on DB pod${NC}"
 import_testdata_to_db
 
-echo "${GREEN_BG}data should now be imported to the ephemeral DB. you can retrieve the data via the smart-proxy API${NC}"
+echo "${GREEN_BG}data should now be imported to the ephemeral DB. you should be able to retrieve the data via the smart-proxy API${NC}"
 cleanup


### PR DESCRIPTION
# Description
- wait for DB migrations to finish (waits until db-writer pod is in a `Ready` state, it will not be Ready until all init containers finish (`execute-migrations-init` container has to finish successfully, otherwise db-writer won't be Ready)
- fix a case when a user has more than 1 existing namespace and doesn't want to use the first one (cannot easily tell which is older/newer because `bonfire` sorts the namespaces alphabetically)
- load `EPH_NAMESPACE` from exported env var, if any, to bypass new namespace reservation

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
run the script with the above cases

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
