### PR TITLE
Enable more linters on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,9 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-          args: --timeout=3m
+          args: >
+            --enable=goimports,gosimple,nilerr,prealloc,revive,staticcheck,unconvert,unused,whitespace,zerologlint
+            --timeout=3m
           
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -279,7 +279,6 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 			c.Storage.PGUsername = clowder.LoadedConfig.Database.Username
 			c.Storage.PGPassword = clowder.LoadedConfig.Database.Password
 		}
-
 	} else {
 		fmt.Println("Clowder is disabled")
 	}
@@ -289,6 +288,7 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 
 // GetOrganizationsToExport retrieves org_id list from provided CSV file
 func GetOrganizationsToExport(config *ConfigStruct) ([]string, error) {
+	const errorMessage = "GetOrganizationsToExport"
 	if !config.Storage.EnableOrgIDFiltering {
 		log.Info().Msg("Selective export based on org_ids disabled")
 		return nil, nil
@@ -296,21 +296,21 @@ func GetOrganizationsToExport(config *ConfigStruct) ([]string, error) {
 
 	if config.Storage.OrganizationIDsCSVFile == "" {
 		err := errors.New("Selective export based on org_ids enabled, but none supplied")
-		log.Error().Err(err)
+		log.Error().Err(err).Msg(errorMessage)
 		return nil, err
 	}
 
 	organizationIDsData, err := os.ReadFile(config.Storage.OrganizationIDsCSVFile)
 	if err != nil {
 		err := errors.New("Organization IDs file could not be opened")
-		log.Error().Err(err)
+		log.Error().Err(err).Msg(errorMessage)
 		return nil, err
 	}
 
 	organizationsToExport, err := LoadOrgIDsFromCSV(bytes.NewBuffer(organizationIDsData))
 	if err != nil {
 		err := errors.New("Organization IDs CSV file could not be processed")
-		log.Error().Err(err)
+		log.Error().Err(err).Msg(errorMessage)
 		return nil, err
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ func mustSetEnv(t *testing.T, key, val string) {
 
 // TestLoadDefaultConfiguration test loads a configuration file for testing
 // with check that load was correct
-func TestLoadDefaultConfiguration(t *testing.T) {
+func TestLoadDefaultConfiguration(_ *testing.T) {
 	os.Clearenv()
 	mustLoadConfiguration("nonExistingEnvVar")
 }

--- a/exporter.go
+++ b/exporter.go
@@ -148,7 +148,7 @@ func constructIgnoredTablesMap(input string) IgnoredTables {
 	tables := strings.Split(input, ",")
 
 	// prepare empty map with given capacity
-	var m IgnoredTables = make(IgnoredTables, len(tables))
+	var m = make(IgnoredTables, len(tables))
 
 	// don't add empty string into a map
 	if input == "" {
@@ -201,7 +201,6 @@ func performDataExportToS3(configuration *ConfigStruct,
 	exportDisabledRules bool,
 	operationLogger *zerolog.Logger, limit int,
 	ignoredTables IgnoredTables) (int, error) {
-
 	operationLogger.Info().Msg("Exporting to S3")
 
 	operationLogger.Info().Msg(readingListOfTables)
@@ -313,12 +312,11 @@ func performDataExportToS3(configuration *ConfigStruct,
 }
 
 // performDataExportToFiles exports all tables and metadata info files
-func performDataExportToFiles(configuration *ConfigStruct,
+func performDataExportToFiles(_ *ConfigStruct,
 	storage *DBStorage, exportMetadata bool,
 	exportDisabledRules bool,
 	operationLogger *zerolog.Logger, limit int,
 	ignoredTables IgnoredTables) (int, error) {
-
 	operationLogger.Info().Msg("Exporting to file")
 
 	operationLogger.Info().Msg(readingListOfTables)
@@ -506,7 +504,7 @@ func parseFlags() (cliFlags CliFlags) {
 type DummyWriter struct{}
 
 // Write method satisfies noop io.Write
-func (w DummyWriter) Write(p []byte) (n int, err error) {
+func (w DummyWriter) Write(_ []byte) (n int, err error) {
 	return 0, nil
 }
 
@@ -534,7 +532,6 @@ func createOperationLog(cliFlags CliFlags, buffer *bytes.Buffer) (zerolog.Logger
 	}
 
 	return dummyLogger, nil
-
 }
 
 func setObjectPrefix(prefix, object string) string {

--- a/s3.go
+++ b/s3.go
@@ -123,7 +123,6 @@ func s3BucketExists(ctx context.Context, minioClient *minio.Client,
 // parameter into given bucket under selected object name
 func storeTableNames(ctx context.Context, minioClient *minio.Client,
 	bucketName string, objectName string, tableNames []TableName) error {
-
 	// check if Minio client has been passed to this function
 	if minioClient == nil {
 		err := errors.New(minioClientIsNil)
@@ -182,7 +181,6 @@ func storeTableNames(ctx context.Context, minioClient *minio.Client,
 // into given bucket under selected object name
 func storeDisabledRulesIntoS3(ctx context.Context, minioClient *minio.Client,
 	bucketName string, objectName string, disabledRulesInfo []DisabledRuleInfo) error {
-
 	// check if Minio client has been passed to this function
 	if minioClient == nil {
 		err := errors.New(minioClientIsNil)

--- a/s3.go
+++ b/s3.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -94,7 +94,6 @@ func NewS3Connection(configuration *ConfigStruct) (*minio.Client, context.Contex
 // accessed by current client
 func s3BucketExists(ctx context.Context, minioClient *minio.Client,
 	bucketName string) (bool, error) {
-
 	// check if Minio client has been passed to this function
 	if minioClient == nil {
 		err := errors.New(minioClientIsNil)

--- a/s3_test.go
+++ b/s3_test.go
@@ -172,9 +172,7 @@ func TestS3BucketExists(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
-
 	}
-
 }
 
 // Test case specification structure for function main.storeTableNames

--- a/s3_test.go
+++ b/s3_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -118,7 +118,6 @@ func TestNewS3Connection(t *testing.T) {
 				assert.NotNil(t, client)
 			}
 		})
-
 	}
 }
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -253,7 +253,5 @@ func TestStoreTable(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
-
 	}
-
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -35,7 +35,7 @@ import (
 	main "github.com/RedHatInsights/insights-results-aggregator-exporter"
 )
 
-const NO_LIMITS = -1
+const NoLimits = -1
 
 var testConfig = main.StorageConfiguration{
 	Driver:                 "postgres",
@@ -476,7 +476,7 @@ func TestReadTable(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, &testConfig)
 
 	// call the tested method
-	values, err := storage.ReadTable("table_name", NO_LIMITS)
+	values, err := storage.ReadTable("table_name", NoLimits)
 	if err != nil {
 		t.Errorf("error was not expected %s", err)
 	}
@@ -574,7 +574,7 @@ func TestReadTableWithSelectiveExportDisallowedTable(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, config)
 
 	// call the tested method, table name must be in predefined list
-	values, err := storage.ReadTable("table_name", NO_LIMITS)
+	values, err := storage.ReadTable("table_name", NoLimits)
 	if err != nil {
 		t.Errorf("error was not expected %s", err)
 	}
@@ -624,7 +624,7 @@ func TestReadTableWithSelectiveExportAllowedTableSingleOrgID(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, config)
 
 	// call the tested method, table name must be in predefined list
-	values, err := storage.ReadTable("report", NO_LIMITS)
+	values, err := storage.ReadTable("report", NoLimits)
 	if err != nil {
 		t.Errorf("error was not expected %s", err)
 	}
@@ -674,7 +674,7 @@ func TestReadTableWithSelectiveExportAllowedTable(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, config)
 
 	// call the tested method, table name must be in predefined list
-	values, err := storage.ReadTable("report", NO_LIMITS)
+	values, err := storage.ReadTable("report", NoLimits)
 	if err != nil {
 		t.Errorf("error was not expected %s", err)
 	}
@@ -761,7 +761,7 @@ func TestReadTableOnError(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, &testConfig)
 
 	// call the tested method
-	_, err := storage.ReadTable("table_name", NO_LIMITS)
+	_, err := storage.ReadTable("table_name", NoLimits)
 	if err != mockedError {
 		t.Errorf("different error was returned: %v", err)
 	}
@@ -877,7 +877,7 @@ func TestStoreTableIntoFile(t *testing.T) {
 	storage := main.NewFromConnection(connection, 1, &testConfig)
 
 	// call the tested method
-	err := storage.StoreTableIntoFile("table_name", NO_LIMITS)
+	err := storage.StoreTableIntoFile("table_name", NoLimits)
 	if err != nil {
 		t.Errorf("error was not expected %s", err)
 	}


### PR DESCRIPTION
# Description

Enable more linters on CI

## Type of change

- Configuration update

## Testing steps

To be done on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
