### PR TITLE
[CCXDEV-16245] Switch to shared gotests reusable workflow

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -6,22 +6,12 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gotests:
-    runs-on: ubuntu-latest
-    name: Go tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.25"
-      - name: Unit tests
-        run: env
-      - name: Retrieve code coverage
-        run: go test -coverprofile coverage.out $(go list ./... | grep -v tests)
-      - name: Display code coverage
-        run: go tool cover -func=coverage.out
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: RedHatInsights/processing-tools/.github/workflows/gotests.yaml@master
+    with:
+      coverage_threshold: 60
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: golangci-lint-full
 
   - repo: https://github.com/RedHatInsights/processing-tools
-    rev: v0.1.0
+    rev: v0.3.0
     hooks:
       - id: abcgo
         args: ['--threshold=75']


### PR DESCRIPTION
# Description

- Replace inline `gotests.yaml` with reusable workflow from processing-tools
- Coverage threshold preserved at 60%

Fixes CCXDEV-16245

## Type of change

- Configuration update