### PR TITLE
fix: use existing tableNameMsg constant and extract text/csv content type

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -80,7 +80,7 @@ func TableMetadataToCSV(buffer io.Writer, tableNames []TableName, storage DBStor
 
 	writer := csv.NewWriter(buffer)
 
-	err := writer.Write([]string{"Table name", "Records"})
+	err := writer.Write([]string{tableNameMsg, "Records"})
 	if err != nil {
 		log.Error().Err(err).Msg(writeOneRowToCSV)
 		return err

--- a/exporter.go
+++ b/exporter.go
@@ -40,6 +40,7 @@ const (
 	operationFailedMessage = "Operation failed"
 	listOfTablesMsg        = "List of tables"
 	tableNameMsg           = "Table name"
+	contentTypeCSV         = "text/csv"
 	tableIsIgnored         = "Table is ignored, skipping export"
 )
 

--- a/file.go
+++ b/file.go
@@ -48,7 +48,7 @@ func storeTableNamesIntoFile(fileName string, tableNames []TableName) error {
 
 	// initialize CSV writer
 	writer := csv.NewWriter(fout)
-	var data = [][]string{{"Table name"}}
+	var data = [][]string{{tableNameMsg}}
 
 	// header
 	err = writer.WriteAll(data)

--- a/s3.go
+++ b/s3.go
@@ -148,7 +148,7 @@ func storeTableNames(ctx context.Context, minioClient *minio.Client,
 	buffer := new(bytes.Buffer)
 
 	writer := csv.NewWriter(buffer)
-	var data = [][]string{{"Table name"}}
+	var data = [][]string{{tableNameMsg}}
 
 	err := writer.WriteAll(data)
 	if err != nil {
@@ -167,7 +167,7 @@ func storeTableNames(ctx context.Context, minioClient *minio.Client,
 	reader := io.Reader(buffer)
 
 	// store CSV data into S3/Minio
-	options := minio.PutObjectOptions{ContentType: "text/csv"}
+	options := minio.PutObjectOptions{ContentType: contentTypeCSV}
 	_, err = minioClient.PutObject(ctx, bucketName, objectName, reader, -1, options)
 	if err != nil {
 		return err
@@ -213,7 +213,7 @@ func storeDisabledRulesIntoS3(ctx context.Context, minioClient *minio.Client,
 	reader := io.Reader(buffer)
 
 	// store CSV data into S3/Minio
-	options := minio.PutObjectOptions{ContentType: "text/csv"}
+	options := minio.PutObjectOptions{ContentType: contentTypeCSV}
 	_, err = minioClient.PutObject(ctx, bucketName, objectName, reader, -1, options)
 	if err != nil {
 		return err

--- a/storage.go
+++ b/storage.go
@@ -470,7 +470,7 @@ func (storage DBStorage) StoreTable(ctx context.Context,
 	// https://docs.min.io/docs/golang-client-api-reference#PutObject
 	size := buffer.Len()
 
-	options := minio.PutObjectOptions{ContentType: "text/csv"}
+	options := minio.PutObjectOptions{ContentType: contentTypeCSV}
 	objectName := setObjectPrefix(prefix, string(tableName)) + CSVFileExtension
 	_, err = minioClient.PutObject(ctx, bucketName, objectName, reader, int64(size), options)
 	if err != nil {
@@ -660,7 +660,7 @@ func (storage DBStorage) StoreTableMetadataIntoS3(ctx context.Context,
 	// write CSV data into S3 bucket or Minio bucket
 	reader := io.Reader(buffer)
 
-	options := minio.PutObjectOptions{ContentType: "text/csv"}
+	options := minio.PutObjectOptions{ContentType: contentTypeCSV}
 	_, err = minioClient.PutObject(ctx, bucketName, objectName, reader, -1, options)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What broke and why

golangci-lint v2.12.0 flagged two repeated string literals:

1. `"Table name"` — appears 3 times across `csv.go`, `file.go`, and `s3.go`, but a constant `tableNameMsg` already exists in `exporter.go` and was not being used in those files.
2. `"text/csv"` — appears 4 times across `s3.go` and `storage.go` with no corresponding constant.

## Why this fix

- For `"Table name"`: using the existing constant is the correct fix — it was already defined for exactly this purpose.
- For `"text/csv"`: adding `contentTypeCSV` follows the same pattern and makes the content type consistent and change-proof.

## Unblocks

Allows https://github.com/RedHatInsights/insights-results-aggregator-exporter/pull/610 to pass CI and merge.